### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,11 +4,11 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "rules_go", version = "0.57.0")
-bazel_dep(name = "gazelle", version = "0.45.0")
-bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
-bazel_dep(name = "rules_pkg", version = "1.0.1")
-bazel_dep(name = "rules_shell", version = "0.6.1")
+bazel_dep(name = "rules_go", version = "0.61.1")
+bazel_dep(name = "gazelle", version = "0.51.3")
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
+bazel_dep(name = "rules_pkg", version = "1.2.0")
+bazel_dep(name = "rules_shell", version = "0.8.0")
 
 # Go SDK
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
@@ -20,7 +20,7 @@ go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 
 # multitool
-bazel_dep(name = "rules_multitool", version = "1.9.0")
+bazel_dep(name = "rules_multitool", version = "1.11.1")
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* rules_go: 0.57.0 -> 0.61.1
* gazelle: 0.45.0 -> 0.51.3
* buildifier_prebuilt: 8.2.0.2 -> 8.5.1.2
* rules_pkg: 1.0.1 -> 1.2.0
* rules_shell: 0.6.1 -> 0.8.0
* rules_multitool: 1.9.0 -> 1.11.1